### PR TITLE
[MRG] workflow for gtdb-rs214 genomic

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,3 +6,4 @@ channels:
 dependencies:
   - snakemake>=7.25,<8
   - pandas>2,<3
+  - sourmash>4.8,<5

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,8 @@
+name: database-releases
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - snakemake>=7.25,<8
+  - pandas>2,<3

--- a/gtdb-rs214.genomic/README.md
+++ b/gtdb-rs214.genomic/README.md
@@ -1,0 +1,12 @@
+To release the next GTDB version:
+
+1. copy the code in this folder to a new one for the release version
+2. update config.yml with new gtdb information (metadata urls, filenames, tag, etc)
+3. update wort manifest and add new to config.yml
+4. run `snakemake prepare` to cross-check signatures needed  against available wort sigs
+5. run `snakemake build` to build the base zipfiles
+6. run `snakemake check` to check that these zipfiles have all needed sigs
+7. run `snakemake -s release.smk` to build sbt, lca db's from the zipfiles
+
+Notes:
+- building SBTs requires more memory than any other db. I will add resources after benchmarking (tbd)

--- a/gtdb-rs214.genomic/README.md
+++ b/gtdb-rs214.genomic/README.md
@@ -1,12 +1,16 @@
 To release the next GTDB version:
 
-1. copy the code in this folder to a new one for the release version
-2. update config.yml with new gtdb information (metadata urls, filenames, tag, etc)
-3. update wort manifest and add new to config.yml
+1. update wort manifest. This will build a new manifest with today's date:
+```
+bash /group/ctbrowngrp/sourmash-db/wort-manifests/update-wort-manifest.sh
+```
+2. copy the code in this folder to a new one for the release version
+3. update `config.yml` with new gtdb information (metadata urls, filenames, tag, new wort manifest,etc)
 4. run `snakemake prepare` to cross-check signatures needed  against available wort sigs
 5. run `snakemake build` to build the base zipfiles
 6. run `snakemake check` to check that these zipfiles have all needed sigs
 7. run `snakemake -s release.smk` to build sbt, lca db's from the zipfiles
+8. release databases will be in `/group/ctbrowngrp/sourmash-db/{name}-{tag}`, using params you set in `config.yml`
 
 Notes:
-- building SBTs requires more memory than any other db. I will add resources after benchmarking (tbd)
+- building SBTs requires more memory than any other db. I will add resources to rules after benchmarking (tbd)

--- a/gtdb-rs214.genomic/README.md
+++ b/gtdb-rs214.genomic/README.md
@@ -4,14 +4,16 @@ To release the next GTDB version:
 ```
 bash /group/ctbrowngrp/sourmash-db/wort-manifests/update-wort-manifest.sh
 ```
-2. copy the code in this folder to a new one for the release version
+2. Copy the code in this folder (snakefiles, environment.yml config.yaml) to a new one for the release version
 3. update `config.yml` with new gtdb information (metadata urls, filenames, tag, new wort manifest,etc)
-4. run `snakemake prepare` to cross-check signatures needed  against available wort sigs
-5. run `snakemake build` to build the base zipfiles
-6. run `snakemake check` to check that these zipfiles have all needed sigs
-7. run `snakemake -s release.smk` to build sbt, lca db's from the zipfiles
-8. release databases will be in `/group/ctbrowngrp/sourmash-db/{name}-{tag}`, using params you set in `config.yml`
-9. update sourmash docs (databases.md) with the new db information
+4. update the `environment.yml` as needed/desired, install, and activate
+5. run `snakemake prepare` to cross-check signatures needed  against available wort sigs
+6. run `snakemake build` to build the base zipfiles
+7. run `snakemake check` to check that these zipfiles have all needed sigs
+8. run `snakemake -s release.smk` to build sbt, lca db's from the zipfiles
+9. release databases will be in `/group/ctbrowngrp/sourmash-db/{name}-{tag}`, using params you set in `config.yml`
+10. update sourmash docs (databases.md) with the new db information
 
 Notes:
-- building SBTs requires more memory than any other db. I will add resources to rules after benchmarking (tbd)
+- If you want to take advantage of the automated resource management, set up a slurm profile and pass into snakemake (e.g. snakemake --profile slurm)
+- This could usefully be automated into an `sbatch` file sometime in the future.

--- a/gtdb-rs214.genomic/README.md
+++ b/gtdb-rs214.genomic/README.md
@@ -11,6 +11,7 @@ bash /group/ctbrowngrp/sourmash-db/wort-manifests/update-wort-manifest.sh
 6. run `snakemake check` to check that these zipfiles have all needed sigs
 7. run `snakemake -s release.smk` to build sbt, lca db's from the zipfiles
 8. release databases will be in `/group/ctbrowngrp/sourmash-db/{name}-{tag}`, using params you set in `config.yml`
+9. update sourmash docs (databases.md) with the new db information
 
 Notes:
 - building SBTs requires more memory than any other db. I will add resources to rules after benchmarking (tbd)

--- a/gtdb-rs214.genomic/Snakefile
+++ b/gtdb-rs214.genomic/Snakefile
@@ -1,6 +1,5 @@
-# update the wort manifest to reflect all available signatures; use updated version here
-#DATABASES = ['/group/ctbrowngrp/sourmash-db/wort-manifests/2023-05-05.wort.sqlmf'] # wort manifest
-DATABASES = ['/group/ctbrowngrp/sourmash-db/wort-manifests/entire.2022-04-26.sqlmf'] # wort manifest
+### update the wort manifest to reflect all available signatures; use updated version here
+DATABASES = ['/group/ctbrowngrp/sourmash-db/wort-manifests/2023-05-04.wort.sqlmf'] # wort manifest
 
 ### update with metadata for new GTDB release ###
 TAG = "rs214"
@@ -83,25 +82,35 @@ rule picklist_confirm:
             {input.zip} --fail
         """
 
-rule build_zip:
+rule build_abund_zip:
     input:
         databases = DATABASES,
         manifest = "gtdb-{tag}.manifest.csv",
     output:
-        "gtdb-{tag}-k{k}.zip"
+        "gtdb-{tag}-k{k}.abund.zip"
     shell:
         """
         sourmash sig cat {input.manifest} -k {wildcards.k} -o {output}
         """
 
+rule build_release_zip:
+    input:
+        abund_zip="gtdb-{tag}-k{k}.abund.zip"
+    output:
+        "gtdb-{tag}-k{k}.zip"
+    shell:
+        """
+        sourmash sig flatten {input} -k {wildcards.k} -o {output}
+        """
+
 
 rule build_representatives_zip:
     input:
-        full_zip = "gtdb-{tag}-k{k}.zip",
+        abund_zip = "gtdb-{tag}-k{k}.zip",
         reps_picklist = "gtdb-{tag}.lineages.reps.csv", 
     output:
         "gtdb-{tag}-k{k}.reps.zip"
     shell:
         """
-        sourmash sig cat --picklist {input.reps_picklist}:ident:ident -k {wildcards.k} -o {output}
+        sourmash sig flatten --picklist {input.reps_picklist}:ident:ident -k {wildcards.k} -o {output}
         """

--- a/gtdb-rs214.genomic/Snakefile
+++ b/gtdb-rs214.genomic/Snakefile
@@ -1,5 +1,5 @@
 ### update the wort manifest to reflect all available signatures; use updated version here
-DATABASES = ['/group/ctbrowngrp/sourmash-db/wort-manifests/2023-05-04.wort.sqlmf'] # wort manifest
+DATABASES = ['/group/ctbrowngrp/sourmash-db/wort-manifests/2023-05-05.wort.sqlmf'] # wort manifest
 
 ### update with metadata for new GTDB release ###
 TAG = "rs214"
@@ -17,12 +17,12 @@ rule all:
 
 rule build:
     input:
-        expand("gtdb-{tag}-k{k}.zip", tag=TAG, k=KSIZES),
-        expand("gtdb-{tag}-k{k}.reps.zip", tag=TAG, k=KSIZES)
+        expand("releases/gtdb-{tag}-k{k}.zip", tag=TAG, k=KSIZES),
+        expand("releases/gtdb-{tag}-k{k}.reps.zip", tag=TAG, k=KSIZES)
 
 rule check:
     input:
-        expand("gtdb-{tag}-k{k}.zip.check", tag=TAG, k=KSIZES)
+        expand("gtdb-{tag}-k{k}.abund.zip.check", tag=TAG, k=KSIZES)
 
 rule download_gtdb_metadata:
     output:
@@ -73,9 +73,9 @@ rule picklist_check:
 rule picklist_confirm:
     input:
         picklist = "gtdb-{tag}.lineages.csv",
-        zip = "gtdb-{tag}-k{k}.zip",
+        zip = "gtdb-{tag}-k{k}.abund.zip",
     output:
-        confirm = touch("gtdb-{tag}-k{k}.zip.check")
+        confirm = touch("gtdb-{tag}-k{k}.abund.zip.check")
     shell:
         """
         sourmash sig check --picklist {input.picklist}:ident:ident \
@@ -97,7 +97,7 @@ rule build_release_zip:
     input:
         abund_zip="gtdb-{tag}-k{k}.abund.zip"
     output:
-        "gtdb-{tag}-k{k}.zip"
+        "releases/gtdb-{tag}-k{k}.zip"
     shell:
         """
         sourmash sig flatten {input} -k {wildcards.k} -o {output}
@@ -109,7 +109,7 @@ rule build_representatives_zip:
         abund_zip = "gtdb-{tag}-k{k}.zip",
         reps_picklist = "gtdb-{tag}.lineages.reps.csv", 
     output:
-        "gtdb-{tag}-k{k}.reps.zip"
+        "releases/gtdb-{tag}-k{k}.reps.zip"
     shell:
         """
         sourmash sig flatten --picklist {input.reps_picklist}:ident:ident -k {wildcards.k} -o {output}

--- a/gtdb-rs214.genomic/Snakefile
+++ b/gtdb-rs214.genomic/Snakefile
@@ -1,7 +1,6 @@
-### update the wort manifest to reflect all available signatures; use updated version here
-DATABASES = ['/group/ctbrowngrp/sourmash-db/wort-manifests/2023-05-05.wort.sqlmf'] # wort manifest
-
 configfile: "config.yml"
+
+DATABASES = config['wort_manifest'] 
 
 NAME = config['name']
 TAG = config['tag']
@@ -18,6 +17,10 @@ ARCHAEA_URL=config['archaea_metadata_url']
 ARCHAEA_FILE=config['archaea_metadata_filename']
 BACTERIA_URL=config['bacteria_metadata_url']
 BACTERIA_FILE=config['bacteria_metadata_filename']
+
+# logs dir
+LOGS='logs'
+
 ########################################
 
 wildcard_constraints:
@@ -79,11 +82,13 @@ rule picklist_check:
     output:
         missing = "gtdb-{tag}.missing.csv",
         manifest = "gtdb-{tag}.manifest.csv",
+    log: f"{LOGS}/gtdb-{{tag}}.picklist_check.log"
+    benchmark: f"{LOGS}/gtdb-{{tag}}.picklist_check.benchmark"
     shell:
         """
         sourmash sig check --picklist {input.picklist}:ident:ident \
             {input.databases} --output-missing {output.missing} \
-            --save-manifest {output.manifest}
+            --save-manifest {output.manifest} 2> {log}
         touch {output.missing}
         """
 
@@ -93,20 +98,24 @@ rule build_abund_zip:
         manifest = "gtdb-{tag}.manifest.csv",
     output:
         "gtdb-{tag}-k{k}.abund.zip"
+    log: f"{LOGS}/gtdb-{{tag}}-k{{k}}.build_abund_zip.log"
+    benchmark: f"{LOGS}/gtdb-{{tag}}-k{{k}}.build_abund_zip.benchmark"
     shell:
         """
-        sourmash sig cat {input.manifest} -k {wildcards.k} -o {output}
+        sourmash sig cat {input.manifest} -k {wildcards.k} -o {output} 2> {log}
         """
 
-rule build_representatives_zip:
+rule extract_representatives_zip:
     input:
         abund_zip = "gtdb-{tag}-k{k}.abund.zip",
         reps_picklist = REPS_TAXONOMY_FILE ,
     output:
         "gtdb-{tag}-reps.k{k}.abund.zip"
+    log: f"{LOGS}/gtdb-{{tag}}-k{{k}}.extract_reps_zip.log"
+    benchmark: f"{LOGS}/gtdb-{{tag}}-k{{k}}.extract_reps_zip.benchmark"
     shell:
         """
-        sourmash sig extract {input.abund_zip} --picklist {input.reps_picklist}:ident:ident -k {wildcards.k} -o {output}
+        sourmash sig extract {input.abund_zip} --picklist {input.reps_picklist}:ident:ident -k {wildcards.k} -o {output} 2> {log}
         """
 
 rule picklist_confirm:
@@ -115,10 +124,12 @@ rule picklist_confirm:
         zip = "gtdb-{tag}-k{k}.abund.zip",
     output:
         confirm = touch("gtdb-{tag}-k{k}.abund.zip.check")
+    log: f"{LOGS}/gtdb-{{tag}}-k{{k}}.abund.picklist_confirm.log"
+    benchmark: f"{LOGS}/gtdb-{{tag}}-k{{k}}.abund.picklist_confirm.benchmark"
     shell:
         """
         sourmash sig check --picklist {input.picklist}:ident:ident \
-            {input.zip} --fail
+            {input.zip} --fail 2> {log}
         """
 
 rule picklist_confirm_reps:
@@ -127,9 +138,11 @@ rule picklist_confirm_reps:
         zip = "gtdb-{tag}-reps.k{k}.abund.zip",
     output:
         confirm = touch("gtdb-{tag}-reps.k{k}.abund.zip.check")
+    log: f"{LOGS}/gtdb-{{tag}}-k{{k}}.reps.picklist_confirm.log"
+    benchmark: f"{LOGS}/gtdb-{{tag}}-k{{k}}.reps.picklist_confirm.benchmark"
     shell:
         """
         sourmash sig check --picklist {input.picklist}:ident:ident \
-            {input.zip} --fail
+            {input.zip} --fail 2> {log}
         """
 

--- a/gtdb-rs214.genomic/Snakefile
+++ b/gtdb-rs214.genomic/Snakefile
@@ -1,28 +1,45 @@
 ### update the wort manifest to reflect all available signatures; use updated version here
 DATABASES = ['/group/ctbrowngrp/sourmash-db/wort-manifests/2023-05-05.wort.sqlmf'] # wort manifest
 
-### update with metadata for new GTDB release ###
-TAG = "rs214"
-ARCHAEA_URL='https://data.gtdb.ecogenomic.org/releases/release214/214.0/ar53_metadata_r214.tar.gz'
-ARCHAEA_FILE='ar53_metadata_r214.tar.gz'
-BACTERIA_URL='https://data.gtdb.ecogenomic.org/releases/release214/214.0/bac120_metadata_r214.tar.gz'
-BACTERIA_FILE='bac120_metadata_r214.tar.gz'
-########################################
-KSIZES=[21,31,51]
+configfile: "config.yml"
 
-rule all:
+NAME = config['name']
+TAG = config['tag']
+KSIZES = config['ksizes']
+SCALED = config['scaled']
+
+# taxonomy info
+TAXONOMY_FILE = f"{NAME}-{TAG}.lineages.csv"
+REPS_TAXONOMY_FILE = f"{NAME}-{TAG}.lineages.reps.csv"
+
+wildcard_constraints:
+    filename = "[^/]+"
+ARCHAEA_URL=config['archaea_metadata_url']
+ARCHAEA_FILE=config['archaea_metadata_filename']
+BACTERIA_URL=config['bacteria_metadata_url']
+BACTERIA_FILE=config['bacteria_metadata_filename']
+########################################
+
+wildcard_constraints:
+    ksize = "\d+",
+    name = "[^/]+",
+    tag = "[^/\.]+",
+    filename = "[^/]+"
+
+rule prepare:
     input:
         expand("gtdb-{tag}.missing.csv", tag=TAG),
         expand("gtdb-{tag}.manifest.csv", tag=TAG),
 
 rule build:
     input:
-        expand("releases/gtdb-{tag}-k{k}.zip", tag=TAG, k=KSIZES),
-        expand("releases/gtdb-{tag}-k{k}.reps.zip", tag=TAG, k=KSIZES)
+        expand("gtdb-{tag}-k{k}.abund.zip", tag=TAG, k=KSIZES),
+        expand("gtdb-{tag}-reps.k{k}.abund.zip", tag=TAG, k=KSIZES),
 
 rule check:
     input:
-        expand("gtdb-{tag}-k{k}.abund.zip.check", tag=TAG, k=KSIZES)
+        expand("{name}-{tag}-k{k}.abund.zip.check", name=NAME, tag=TAG, k=KSIZES),
+        expand("{name}-{tag}-reps.k{k}.abund.zip.check", name=NAME, tag=TAG, k=KSIZES),
 
 rule download_gtdb_metadata:
     output:
@@ -47,8 +64,8 @@ rule make_taxonomy:
         ar53_metadata='ar53_metadata_r214.tsv',
         bac120_metadata='bac120_metadata_r214.tsv',
     output:
-        tax_csv="gtdb-{tag}.lineages.csv",
-        reps_csv="gtdb-{tag}.lineages.reps.csv",
+        tax_csv=TAXONOMY_FILE,
+        reps_csv=REPS_TAXONOMY_FILE,
     shell:
         """
         python make-gtdb-taxonomy.py --metadata-files {input.ar53_metadata} {input.bac120_metadata} \
@@ -58,7 +75,7 @@ rule make_taxonomy:
 rule picklist_check:
     input:
         databases = DATABASES,
-        picklist = "gtdb-{tag}.lineages.csv",
+        picklist = TAXONOMY_FILE,
     output:
         missing = "gtdb-{tag}.missing.csv",
         manifest = "gtdb-{tag}.manifest.csv",
@@ -68,18 +85,6 @@ rule picklist_check:
             {input.databases} --output-missing {output.missing} \
             --save-manifest {output.manifest}
         touch {output.missing}
-        """
-
-rule picklist_confirm:
-    input:
-        picklist = "gtdb-{tag}.lineages.csv",
-        zip = "gtdb-{tag}-k{k}.abund.zip",
-    output:
-        confirm = touch("gtdb-{tag}-k{k}.abund.zip.check")
-    shell:
-        """
-        sourmash sig check --picklist {input.picklist}:ident:ident \
-            {input.zip} --fail
         """
 
 rule build_abund_zip:
@@ -93,24 +98,38 @@ rule build_abund_zip:
         sourmash sig cat {input.manifest} -k {wildcards.k} -o {output}
         """
 
-rule build_release_zip:
-    input:
-        abund_zip="gtdb-{tag}-k{k}.abund.zip"
-    output:
-        "releases/gtdb-{tag}-k{k}.zip"
-    shell:
-        """
-        sourmash sig flatten {input} -k {wildcards.k} -o {output}
-        """
-
-
 rule build_representatives_zip:
     input:
-        abund_zip = "gtdb-{tag}-k{k}.zip",
-        reps_picklist = "gtdb-{tag}.lineages.reps.csv", 
+        abund_zip = "gtdb-{tag}-k{k}.abund.zip",
+        reps_picklist = REPS_TAXONOMY_FILE ,
     output:
-        "releases/gtdb-{tag}-k{k}.reps.zip"
+        "gtdb-{tag}-reps.k{k}.abund.zip"
     shell:
         """
-        sourmash sig flatten --picklist {input.reps_picklist}:ident:ident -k {wildcards.k} -o {output}
+        sourmash sig extract {input.abund_zip} --picklist {input.reps_picklist}:ident:ident -k {wildcards.k} -o {output}
         """
+
+rule picklist_confirm:
+    input:
+        picklist = TAXONOMY_FILE, 
+        zip = "gtdb-{tag}-k{k}.abund.zip",
+    output:
+        confirm = touch("gtdb-{tag}-k{k}.abund.zip.check")
+    shell:
+        """
+        sourmash sig check --picklist {input.picklist}:ident:ident \
+            {input.zip} --fail
+        """
+
+rule picklist_confirm_reps:
+    input:
+        picklist = REPS_TAXONOMY_FILE, 
+        zip = "gtdb-{tag}-reps.k{k}.abund.zip",
+    output:
+        confirm = touch("gtdb-{tag}-reps.k{k}.abund.zip.check")
+    shell:
+        """
+        sourmash sig check --picklist {input.picklist}:ident:ident \
+            {input.zip} --fail
+        """
+

--- a/gtdb-rs214.genomic/Snakefile
+++ b/gtdb-rs214.genomic/Snakefile
@@ -1,10 +1,13 @@
 # update the wort manifest to reflect all available signatures; use updated version here
-DATABASES = ['/group/ctbrowngrp/sourmash-db/wort-manifests/2023-05-05.wort.sqlmf'] # wort manifest
+#DATABASES = ['/group/ctbrowngrp/sourmash-db/wort-manifests/2023-05-05.wort.sqlmf'] # wort manifest
+DATABASES = ['/group/ctbrowngrp/sourmash-db/wort-manifests/entire.2022-04-26.sqlmf'] # wort manifest
 
 ### update with metadata for new GTDB release ###
 TAG = "rs214"
-ARCHAEA_METADATA='https://data.gtdb.ecogenomic.org/releases/release214/214.0/ar53_metadata_r214.tar.gz'
-BACTERIA_METADATA='https://data.gtdb.ecogenomic.org/releases/release214/214.0/bac120_metadata_r214.tar.gz'
+ARCHAEA_URL='https://data.gtdb.ecogenomic.org/releases/release214/214.0/ar53_metadata_r214.tar.gz'
+ARCHAEA_FILE='ar53_metadata_r214.tar.gz'
+BACTERIA_URL='https://data.gtdb.ecogenomic.org/releases/release214/214.0/bac120_metadata_r214.tar.gz'
+BACTERIA_FILE='bac120_metadata_r214.tar.gz'
 ########################################
 KSIZES=[21,31,51]
 
@@ -15,7 +18,8 @@ rule all:
 
 rule build:
     input:
-        expand("gtdb-{tag}-k{k}.zip", tag=TAG, k=KSIZES)
+        expand("gtdb-{tag}-k{k}.zip", tag=TAG, k=KSIZES),
+        expand("gtdb-{tag}-k{k}.reps.zip", tag=TAG, k=KSIZES)
 
 rule check:
     input:
@@ -23,15 +27,20 @@ rule check:
 
 rule download_gtdb_metadata:
     output:
-        ar53_metadata='ar53_metadata_r214.tsv',
-        bac120_metadata='bac120_metadata_r214.tsv',
+        arch_metadata='ar53_metadata_r214.tsv',
+        bac_metadata='bac120_metadata_r214.tsv',
     params:
-        arch_metadata=ARCHAEA_METADATA,
-        bact_metadata=BACTERIA_METADATA,
+        arch_url=ARCHAEA_URL,
+        bact_url=BACTERIA_URL,
+        arch_file=ARCHAEA_FILE,
+        bact_file=BACTERIA_FILE,
     shell: 
         """
-    	curl -s -L {params.arch_metadata} | tar xvz
-	    curl -s -L {params.bact_metadata} | tar xvz
+        wget {params.arch_url}
+        wget {params.bact_url}
+        tar xzvf {params.arch_file}
+        tar xzvf {params.bact_file}
+        rm -rf *tar.gz
         """
 
 rule make_taxonomy:
@@ -39,10 +48,12 @@ rule make_taxonomy:
         ar53_metadata='ar53_metadata_r214.tsv',
         bac120_metadata='bac120_metadata_r214.tsv',
     output:
-        tax_csv="gtdb-{tag}.lineages.csv"
+        tax_csv="gtdb-{tag}.lineages.csv",
+        reps_csv="gtdb-{tag}.lineages.reps.csv",
     shell:
         """
-        python make-gtdb-taxonomy.py --metadata-files {input.ar53_metadata} {input.bac120_metadata} -o {output}
+        python make-gtdb-taxonomy.py --metadata-files {input.ar53_metadata} {input.bac120_metadata} \
+               -o {output.tax_csv} --reps-csv {output.reps_csv}
         """
 
 rule picklist_check:
@@ -66,10 +77,11 @@ rule picklist_confirm:
         zip = "gtdb-{tag}-k{k}.zip",
     output:
         confirm = touch("gtdb-{tag}-k{k}.zip.check")
-    shell: """
+    shell:
+        """
         sourmash sig check --picklist {input.picklist}:ident:ident \
             {input.zip} --fail
-    """
+        """
 
 rule build_zip:
     input:
@@ -80,4 +92,16 @@ rule build_zip:
     shell:
         """
         sourmash sig cat {input.manifest} -k {wildcards.k} -o {output}
+        """
+
+
+rule build_representatives_zip:
+    input:
+        full_zip = "gtdb-{tag}-k{k}.zip",
+        reps_picklist = "gtdb-{tag}.lineages.reps.csv", 
+    output:
+        "gtdb-{tag}-k{k}.reps.zip"
+    shell:
+        """
+        sourmash sig cat --picklist {input.reps_picklist}:ident:ident -k {wildcards.k} -o {output}
         """

--- a/gtdb-rs214.genomic/Snakefile
+++ b/gtdb-rs214.genomic/Snakefile
@@ -1,24 +1,25 @@
-DATABASES = ['../wort-manifests/2023-05-05.wort.sqlmf'] # wort manifest
-KSIZES=[21,31,51]
+# update the wort manifest to reflect all available signatures; use updated version here
+DATABASES = ['/group/ctbrowngrp/sourmash-db/wort-manifests/2023-05-05.wort.sqlmf'] # wort manifest
 
-### update here for new GTDB release ###
-NAME="gtdb-rs214"
+### update with metadata for new GTDB release ###
+TAG = "rs214"
 ARCHAEA_METADATA='https://data.gtdb.ecogenomic.org/releases/release214/214.0/ar53_metadata_r214.tar.gz'
 BACTERIA_METADATA='https://data.gtdb.ecogenomic.org/releases/release214/214.0/bac120_metadata_r214.tar.gz'
 ########################################
+KSIZES=[21,31,51]
 
 rule all:
     input:
-        expand("{name}.missing.csv", name=NAME),
-        expand("{name}.manifest.csv", name=NAME),
+        expand("gtdb-{tag}.missing.csv", tag=TAG),
+        expand("gtdb-{tag}.manifest.csv", tag=TAG),
 
 rule build:
     input:
-        expand("{name}-k{k}.zip", name=NAME)
+        expand("gtdb-{tag}-k{k}.zip", tag=TAG, k=KSIZES)
 
 rule check:
     input:
-        expand("{name}-k{k}.zip.check", name=NAME)
+        expand("gtdb-{tag}-k{k}.zip.check", tag=TAG, k=KSIZES)
 
 rule download_gtdb_metadata:
     output:
@@ -38,7 +39,7 @@ rule make_taxonomy:
         ar53_metadata='ar53_metadata_r214.tsv',
         bac120_metadata='bac120_metadata_r214.tsv',
     output:
-        tax_csv="{name}.lineages.csv"
+        tax_csv="gtdb-{tag}.lineages.csv"
     shell:
         """
         python make-gtdb-taxonomy.py --metadata-files {input.ar53_metadata} {input.bac120_metadata} -o {output}
@@ -47,10 +48,10 @@ rule make_taxonomy:
 rule picklist_check:
     input:
         databases = DATABASES,
-        picklist = "{name}.lineages.csv",
+        picklist = "gtdb-{tag}.lineages.csv",
     output:
-        missing = "{D}.missing.csv",
-        manifest = "{D}.manifest.csv",
+        missing = "gtdb-{tag}.missing.csv",
+        manifest = "gtdb-{tag}.manifest.csv",
     shell:
         """
         sourmash sig check --picklist {input.picklist}:ident:ident \
@@ -61,10 +62,10 @@ rule picklist_check:
 
 rule picklist_confirm:
     input:
-        picklist = "{name}.lineages.csv",
-        zip = "{name}-k{k}.zip",
+        picklist = "gtdb-{tag}.lineages.csv",
+        zip = "gtdb-{tag}-k{k}.zip",
     output:
-        confirm = touch("{name}-k{k}.zip.check.check")
+        confirm = touch("gtdb-{tag}-k{k}.zip.check")
     shell: """
         sourmash sig check --picklist {input.picklist}:ident:ident \
             {input.zip} --fail
@@ -73,9 +74,9 @@ rule picklist_confirm:
 rule build_zip:
     input:
         databases = DATABASES,
-        manifest = "{D}.manifest.csv",
+        manifest = "gtdb-{tag}.manifest.csv",
     output:
-        "{name}-k{k}.zip"
+        "gtdb-{tag}-k{k}.zip"
     shell:
         """
         sourmash sig cat {input.manifest} -k {wildcards.k} -o {output}

--- a/gtdb-rs214.genomic/Snakefile
+++ b/gtdb-rs214.genomic/Snakefile
@@ -1,3 +1,20 @@
+"""
+#### Build db zipfile from existing wort signatures ####
+
+To use the 'resources' information in each rule, set up
+a snakemake profile for slurm job submission and pass it
+into snakemake when running, e.g.
+
+    `snakemake --profile slurm`
+
+These resources represent my best guess, as I ran this
+workflow interactively prior to adding benchmarking.
+Benchmark files should now be produced here that
+can be used to tune resources in the future if needed.
+
+Resource 'time' is excessive as jobs will exit when finished.
+"""
+
 configfile: "config.yml"
 
 DATABASES = config['wort_manifest'] 
@@ -53,6 +70,11 @@ rule download_gtdb_metadata:
         bact_url=BACTERIA_URL,
         arch_file=ARCHAEA_FILE,
         bact_file=BACTERIA_FILE,
+    threads: 1
+    resources:
+        mem_mb= lambda wildcards, attempt: attempt * 3000,
+        time= 240,
+        partition='high2',
     shell: 
         """
         wget {params.arch_url}
@@ -69,6 +91,11 @@ rule make_taxonomy:
     output:
         tax_csv=TAXONOMY_FILE,
         reps_csv=REPS_TAXONOMY_FILE,
+    threads: 1
+    resources:
+        mem_mb= lambda wildcards, attempt: attempt * 3000,
+        time= 240,
+        partition='high2',
     shell:
         """
         python make-gtdb-taxonomy.py --metadata-files {input.ar53_metadata} {input.bac120_metadata} \
@@ -84,6 +111,11 @@ rule picklist_check:
         manifest = "gtdb-{tag}.manifest.csv",
     log: f"{LOGS}/gtdb-{{tag}}.picklist_check.log"
     benchmark: f"{LOGS}/gtdb-{{tag}}.picklist_check.benchmark"
+    threads: 1
+    resources:
+        mem_mb= lambda wildcards, attempt: attempt * 6000,
+        time= 10000,
+        partition='high2',
     shell:
         """
         sourmash sig check --picklist {input.picklist}:ident:ident \
@@ -100,6 +132,11 @@ rule build_abund_zip:
         "gtdb-{tag}-k{k}.abund.zip"
     log: f"{LOGS}/gtdb-{{tag}}-k{{k}}.build_abund_zip.log"
     benchmark: f"{LOGS}/gtdb-{{tag}}-k{{k}}.build_abund_zip.benchmark"
+    threads: 1
+    resources:
+        mem_mb= lambda wildcards, attempt: attempt * 10000,
+        time= 6000,
+        partition='bmh',
     shell:
         """
         sourmash sig cat {input.manifest} -k {wildcards.k} -o {output} 2> {log}
@@ -113,6 +150,11 @@ rule extract_representatives_zip:
         "gtdb-{tag}-reps.k{k}.abund.zip"
     log: f"{LOGS}/gtdb-{{tag}}-k{{k}}.extract_reps_zip.log"
     benchmark: f"{LOGS}/gtdb-{{tag}}-k{{k}}.extract_reps_zip.benchmark"
+    threads: 1
+    resources:
+        mem_mb= lambda wildcards, attempt: attempt * 3000,
+        time= 6000,
+        partition='high2',
     shell:
         """
         sourmash sig extract {input.abund_zip} --picklist {input.reps_picklist}:ident:ident -k {wildcards.k} -o {output} 2> {log}
@@ -126,6 +168,11 @@ rule picklist_confirm:
         confirm = touch("gtdb-{tag}-k{k}.abund.zip.check")
     log: f"{LOGS}/gtdb-{{tag}}-k{{k}}.abund.picklist_confirm.log"
     benchmark: f"{LOGS}/gtdb-{{tag}}-k{{k}}.abund.picklist_confirm.benchmark"
+    threads: 1
+    resources:
+        mem_mb= lambda wildcards, attempt: attempt * 3000,
+        time=6000,
+        partition='high2',
     shell:
         """
         sourmash sig check --picklist {input.picklist}:ident:ident \
@@ -140,6 +187,11 @@ rule picklist_confirm_reps:
         confirm = touch("gtdb-{tag}-reps.k{k}.abund.zip.check")
     log: f"{LOGS}/gtdb-{{tag}}-k{{k}}.reps.picklist_confirm.log"
     benchmark: f"{LOGS}/gtdb-{{tag}}-k{{k}}.reps.picklist_confirm.benchmark"
+    threads: 1
+    resources:
+        mem_mb= lambda wildcards, attempt: attempt * 3000,
+        time= 600,
+        partition='high2',
     shell:
         """
         sourmash sig check --picklist {input.picklist}:ident:ident \

--- a/gtdb-rs214.genomic/Snakefile
+++ b/gtdb-rs214.genomic/Snakefile
@@ -1,0 +1,82 @@
+DATABASES = ['../wort-manifests/2023-05-05.wort.sqlmf'] # wort manifest
+KSIZES=[21,31,51]
+
+### update here for new GTDB release ###
+NAME="gtdb-rs214"
+ARCHAEA_METADATA='https://data.gtdb.ecogenomic.org/releases/release214/214.0/ar53_metadata_r214.tar.gz'
+BACTERIA_METADATA='https://data.gtdb.ecogenomic.org/releases/release214/214.0/bac120_metadata_r214.tar.gz'
+########################################
+
+rule all:
+    input:
+        expand("{name}.missing.csv", name=NAME),
+        expand("{name}.manifest.csv", name=NAME),
+
+rule build:
+    input:
+        expand("{name}-k{k}.zip", name=NAME)
+
+rule check:
+    input:
+        expand("{name}-k{k}.zip.check", name=NAME)
+
+rule download_gtdb_metadata:
+    output:
+        ar53_metadata='ar53_metadata_r214.tsv',
+        bac120_metadata='bac120_metadata_r214.tsv',
+    params:
+        arch_metadata=ARCHAEA_METADATA,
+        bact_metadata=BACTERIA_METADATA,
+    shell: 
+        """
+    	curl -s -L {params.arch_metadata} | tar xvz
+	    curl -s -L {params.bact_metadata} | tar xvz
+        """
+
+rule make_taxonomy:
+    input:
+        ar53_metadata='ar53_metadata_r214.tsv',
+        bac120_metadata='bac120_metadata_r214.tsv',
+    output:
+        tax_csv="{name}.lineages.csv"
+    shell:
+        """
+        python make-gtdb-taxonomy.py --metadata-files {input.ar53_metadata} {input.bac120_metadata} -o {output}
+        """
+
+rule picklist_check:
+    input:
+        databases = DATABASES,
+        picklist = "{name}.lineages.csv",
+    output:
+        missing = "{D}.missing.csv",
+        manifest = "{D}.manifest.csv",
+    shell:
+        """
+        sourmash sig check --picklist {input.picklist}:ident:ident \
+            {input.databases} --output-missing {output.missing} \
+            --save-manifest {output.manifest}
+        touch {output.missing}
+        """
+
+rule picklist_confirm:
+    input:
+        picklist = "{name}.lineages.csv",
+        zip = "{name}-k{k}.zip",
+    output:
+        confirm = touch("{name}-k{k}.zip.check.check")
+    shell: """
+        sourmash sig check --picklist {input.picklist}:ident:ident \
+            {input.zip} --fail
+    """
+
+rule build_zip:
+    input:
+        databases = DATABASES,
+        manifest = "{D}.manifest.csv",
+    output:
+        "{name}-k{k}.zip"
+    shell:
+        """
+        sourmash sig cat {input.manifest} -k {wildcards.k} -o {output}
+        """

--- a/gtdb-rs214.genomic/config.yml
+++ b/gtdb-rs214.genomic/config.yml
@@ -1,0 +1,15 @@
+name: gtdb
+tag: rs214
+ksizes:
+- 21
+- 31
+- 51
+scaled: 1000
+lca_json_scaled: 10000
+archaea_metadata_url: 'https://data.gtdb.ecogenomic.org/releases/release214/214.0/ar53_metadata_r214.tar.gz'
+archaea_metadata_filename: 'ar53_metadata_r214.tar.gz'
+bacteria_metadata_url: 'https://data.gtdb.ecogenomic.org/releases/release214/214.0/bac120_metadata_r214.tar.gz'
+bacteria_metadata_filename: 'bac120_metadata_r214.tar.gz'
+tax_column: 2
+tax_keep_version: True
+

--- a/gtdb-rs214.genomic/config.yml
+++ b/gtdb-rs214.genomic/config.yml
@@ -1,5 +1,8 @@
 name: gtdb
 tag: rs214
+### update the wort manifest to reflect all available signatures; use updated version here
+# update this via script in /group/ctbrowngrp/sourmash-db/wort-manifests/
+wort_manifest: '/group/ctbrowngrp/sourmash-db/wort-manifests/2023-05-05.wort.sqlmf'
 ksizes:
 - 21
 - 31

--- a/gtdb-rs214.genomic/config.yml
+++ b/gtdb-rs214.genomic/config.yml
@@ -1,7 +1,6 @@
+release_dir: "/group/ctbrowngrp/sourmash-db" # db's will be built in {release_dir}/{name}-{tag} folder
 name: gtdb
 tag: rs214
-### update the wort manifest to reflect all available signatures; use updated version here
-# update this via script in /group/ctbrowngrp/sourmash-db/wort-manifests/
 wort_manifest: '/group/ctbrowngrp/sourmash-db/wort-manifests/2023-05-05.wort.sqlmf'
 ksizes:
 - 21

--- a/gtdb-rs214.genomic/config.yml
+++ b/gtdb-rs214.genomic/config.yml
@@ -10,6 +10,6 @@ archaea_metadata_url: 'https://data.gtdb.ecogenomic.org/releases/release214/214.
 archaea_metadata_filename: 'ar53_metadata_r214.tar.gz'
 bacteria_metadata_url: 'https://data.gtdb.ecogenomic.org/releases/release214/214.0/bac120_metadata_r214.tar.gz'
 bacteria_metadata_filename: 'bac120_metadata_r214.tar.gz'
-tax_column: 2
+tax_column: 3
 tax_keep_version: True
 

--- a/gtdb-rs214.genomic/environment.yml
+++ b/gtdb-rs214.genomic/environment.yml
@@ -1,4 +1,4 @@
-name: database-releases
+name: release-gtdb-rs214
 channels:
   - conda-forge
   - bioconda

--- a/gtdb-rs214.genomic/make-gtdb-taxonomy.py
+++ b/gtdb-rs214.genomic/make-gtdb-taxonomy.py
@@ -1,0 +1,32 @@
+import sys
+import argparse
+import pandas as pd
+
+def main(args):
+    
+    metadata_dfs = []
+    for metadata_file in args.metadata_files:
+        metadata_info = pd.read_csv(metadata_file, header=0, low_memory=False, sep = "\t") 
+        filtered_metadata_info = metadata_info[["accession", "gtdb_representative", "gtdb_taxonomy"]]
+        filtered_metadata_info["accession"] = metadata_info["accession"].str.replace("RS_", "").str.replace("GB_", "")
+        metadata_dfs.append(filtered_metadata_info)
+        
+    # Write lineages csv file
+    metadata_info = pd.concat(metadata_dfs)
+    metadata_info[["superkingdom","phylum","class","order","family","genus","species"]] = metadata_info["gtdb_taxonomy"].str.split(pat=";", expand=True)
+    metadata_info.drop(columns=["gtdb_taxonomy"], inplace=True)
+    metadata_info.rename(columns={"accession":"ident"}, inplace=True)
+    metadata_info.to_csv(args.output, sep = ',', index=False)
+
+
+def cmdline(sys_args):
+    "Command line entry point w/argparse action."
+    p = argparse.ArgumentParser()
+    p.add_argument("--metadata-files", nargs="+", help="gtdb metadata files")
+    p.add_argument("-o", '--output',  help="output lineages csv")
+    args = p.parse_args()
+    return main(args)
+
+if __name__ == '__main__':
+    returncode = cmdline(sys.argv[1:])
+    sys.exit(returncode)

--- a/gtdb-rs214.genomic/make-gtdb-taxonomy.py
+++ b/gtdb-rs214.genomic/make-gtdb-taxonomy.py
@@ -3,14 +3,14 @@ import argparse
 import pandas as pd
 
 def main(args):
-    
+
     metadata_dfs = []
     for metadata_file in args.metadata_files:
-        metadata_info = pd.read_csv(metadata_file, header=0, low_memory=False, sep = "\t") 
+        metadata_info = pd.read_csv(metadata_file, header=0, low_memory=False, sep = "\t")
         filtered_metadata_info = metadata_info[["accession", "gtdb_representative", "gtdb_taxonomy"]]
         filtered_metadata_info["accession"] = metadata_info["accession"].str.replace("RS_", "").str.replace("GB_", "")
         metadata_dfs.append(filtered_metadata_info)
-        
+
     # Write lineages csv file
     metadata_info = pd.concat(metadata_dfs)
     metadata_info[["superkingdom","phylum","class","order","family","genus","species"]] = metadata_info["gtdb_taxonomy"].str.split(pat=";", expand=True)
@@ -18,15 +18,21 @@ def main(args):
     metadata_info.rename(columns={"accession":"ident"}, inplace=True)
     metadata_info.to_csv(args.output, sep = ',', index=False)
 
+    if args.reps_csv:
+        reps = metadata_info[metadata_info["gtdb_representative"] == 't']
+        reps.to_csv(args.reps_csv, sep=',', index=False)
+
 
 def cmdline(sys_args):
     "Command line entry point w/argparse action."
     p = argparse.ArgumentParser()
     p.add_argument("--metadata-files", nargs="+", help="gtdb metadata files")
     p.add_argument("-o", '--output',  help="output lineages csv")
+    p.add_argument("-r", '--reps-csv',  help="also output representative lineages csv")
     args = p.parse_args()
     return main(args)
 
 if __name__ == '__main__':
     returncode = cmdline(sys.argv[1:])
     sys.exit(returncode)
+

--- a/gtdb-rs214.genomic/release.smk
+++ b/gtdb-rs214.genomic/release.smk
@@ -1,10 +1,11 @@
-import re
 # use the pre-built abund zip to build release databases
+import re
 
 configfile: "config.yml"
 
 NAME = config['name']
 TAG = config['tag']
+RELEASE_DIR= f"/group/ctbrowngrp/sourmash-db/{NAME}-{TAG}"
 KSIZES = config['ksizes']
 SCALED = config['scaled']
 LCA_JSON_SCALED = config['lca_json_scaled']
@@ -24,16 +25,16 @@ ZIP_NAMES = expand([f'{NAME}-{TAG}-k{{k}}', f'{NAME}-{TAG}-reps.k{{k}}'], k=KSIZ
 
 rule all:
     input:
-        expand("releases/{filename}.zip", filename=ZIP_NAMES),
-        expand("releases/{filename}.sbt.zip", filename=ZIP_NAMES),
-        expand("releases/{filename}.lca.json.gz", filename=ZIP_NAMES),
+        expand(f"{RELEASE_DIR}/{{filename}}.zip", filename=ZIP_NAMES),
+        expand(f"{RELEASE_DIR}/{{filename}}.sbt.zip", filename=ZIP_NAMES),
+        expand(f"{RELEASE_DIR}/{{filename}}.lca.json.gz", filename=ZIP_NAMES),
 
 
 rule build_release_zip:
     input:
         abund_zip="{filename}.abund.zip"
     output:
-        "releases/{filename}.zip"
+        f"{RELEASE_DIR}/{{filename}}.zip"
     log: f"LOGS/{{filename}}.release-zip.log"
     benchmark: f"LOGS/{{filename}}.release-zip.benchmark"
     shell:
@@ -47,7 +48,7 @@ rule wc_build_sbt:
     input:
         db = "{filename}.abund.zip",
     output:
-        sbt = "releases/{filename}.sbt.zip",
+        sbt = f"{RELEASE_DIR}/{{filename}}.sbt.zip",
     params:
         scaled = SCALED,
     log: f"LOGS/{{filename}}.release-sbt.log"
@@ -62,7 +63,7 @@ rule wc_build_lca:
     input:
         db = "{filename}.abund.zip",
     output:
-        lca_db = "releases/{filename}.lca.json.gz",
+        lca_db = f"{RELEASE_DIR}/{{filename}}.lca.json.gz",
     params:
         tax = lambda w: REPS_TAXONOMY_FILE if 'reps' in w.filename else TAXONOMY_FILE,
         colnum = TAXONOMY_COLNUM,

--- a/gtdb-rs214.genomic/release.smk
+++ b/gtdb-rs214.genomic/release.smk
@@ -1,3 +1,4 @@
+import re
 # use the pre-built abund zip to build release databases
 
 configfile: "config.yml"
@@ -72,11 +73,12 @@ rule wc_build_lca:
         colnum = TAXONOMY_COLNUM,
         keep_ident_version = "--keep-identifier-v" if TAXONOMY_KEEP_VERSION else "",
         scaled = LCA_JSON_SCALED,
+        ksize = lambda w: re.search(r'k(\d+)', w.filename).group(1),
     shell: 
         """
         sourmash lca index {params.tax} {output.lca_db} {input.db} \
            -C {params.colnum} {params.keep_ident_version} \
            --fail-on-missing-taxonomy --split-identifiers --require-taxonomy \
-           --scaled={params.scaled}
+           --scaled={params.scaled} --ksize {params.ksize}
         """
 

--- a/gtdb-rs214.genomic/release.smk
+++ b/gtdb-rs214.genomic/release.smk
@@ -1,0 +1,82 @@
+# use the pre-built abund zip to build release databases
+
+configfile: "config.yml"
+
+NAME = config['name']
+TAG = config['tag']
+KSIZES = config['ksizes']
+SCALED = config['scaled']
+LCA_JSON_SCALED = config['lca_json_scaled']
+
+# identifier info
+#IDENTIFIERS = config['identifiers']
+#IDENTIFIER_COL = config['identifier_col']
+#IDENTIFIER_TYPE = config['identifier_type']
+
+# taxonomy info
+TAXONOMY_FILE = f"{NAME}-{TAG}.lineages.csv"
+REPS_TAXONOMY_FILE = f"{NAME}-{TAG}.lineages.reps.csv"
+TAXONOMY_COLNUM = int(config['tax_column'])
+TAXONOMY_KEEP_VERSION = bool(config['tax_keep_version'])
+
+wildcard_constraints:
+    filename = "[^/]+"
+
+ZIP_NAMES = expand([f'{NAME}-{TAG}-k{{k}}', f'{NAME}-{TAG}-reps.k{{k}}'], k=KSIZES)
+
+rule all:
+    input:
+        expand("releases/{filename}.zip", filename=ZIP_NAMES),
+        expand("releases/{filename}.sbt.zip", filename=ZIP_NAMES),
+        expand("releases/{filename}.lca.json.gz", filename=ZIP_NAMES),
+
+#rule check:
+#    input:
+#        expand("releases/{filename}.zip.check", name=NAME, tag=TAG, ksize=KSIZES),
+#        expand("releases/{filename}.sbt.zip.check", name=NAME, tag=TAG, ksize=KSIZES),
+#        expand("releases/{filename}.lca.json.gz.check", name=NAME, tag=TAG, ksize=KSIZES),
+
+
+rule build_release_zip:
+    input:
+        abund_zip="{filename}.abund.zip"
+    output:
+        "releases/{filename}.zip"
+    shell:
+        """
+        sourmash sig flatten {input} -o {output}
+        """
+
+
+rule wc_build_sbt:
+    message: "Build SBT {wildcards.filename}.sbt.zip."
+    input:
+        db = "{filename}.abund.zip",
+    output:
+        sbt = "releases/{filename}.sbt.zip",
+    params:
+        scaled = SCALED,
+    shell: 
+        """
+        sourmash index {output.sbt} {input.db} --scaled={params.scaled}
+        """
+
+rule wc_build_lca:
+    message: "Build LCA {wildcards.filename}.lca.json.gz"
+    input:
+        db = "{filename}.abund.zip",
+    output:
+        lca_db = "releases/{filename}.lca.json.gz",
+    params:
+        tax = lambda w: REPS_TAXONOMY_FILE if 'reps' in w.filename else TAXONOMY_FILE,
+        colnum = TAXONOMY_COLNUM,
+        keep_ident_version = "--keep-identifier-v" if TAXONOMY_KEEP_VERSION else "",
+        scaled = LCA_JSON_SCALED,
+    shell: 
+        """
+        sourmash lca index {params.tax} {output.lca_db} {input.db} \
+           -C {params.colnum} {params.keep_ident_version} \
+           --fail-on-missing-taxonomy --split-identifiers --require-taxonomy \
+           --scaled={params.scaled}
+        """
+

--- a/gtdb-rs214.genomic/release.smk
+++ b/gtdb-rs214.genomic/release.smk
@@ -39,7 +39,7 @@ rule build_release_zip:
     benchmark: f"LOGS/{{filename}}.release-zip.benchmark"
     shell:
         """
-        sourmash sig flatten {input} -o {output}
+        sourmash sig flatten {input} -o {output} 2> {log}
         """
 
 
@@ -55,7 +55,7 @@ rule wc_build_sbt:
     benchmark: f"LOGS/{{filename}}.release-sbt.benchmark"
     shell: 
         """
-        sourmash index {output.sbt} {input.db} --scaled={params.scaled}
+        sourmash index {output.sbt} {input.db} --scaled={params.scaled} 2> {log}
         """
 
 rule wc_build_lca:
@@ -77,6 +77,6 @@ rule wc_build_lca:
         sourmash lca index {params.tax} {output.lca_db} {input.db} \
            -C {params.colnum} {params.keep_ident_version} \
            --fail-on-missing-taxonomy --split-identifiers --require-taxonomy \
-           --scaled={params.scaled} --ksize {params.ksize}
+           --scaled={params.scaled} --ksize {params.ksize} 2> {log}
         """
 


### PR DESCRIPTION
This PR adapts the genbank release process to use wort signatures to build databases.

Components:
- `README.md` - instructions for running
- `environment.yml` - file for conda environment
- `config.yml` - configuration file, with all information specific to `gtdb-rs214`
- `make-gtdb-taxonomy.py`- python file to build a taxonomic lineages file from GTDB's bacteria, archea metadata files. This script was written during a session with @mr-eyes @ccbaumler @jeanzzhao
- `Snakefile`:
  - downloads GTDB metadata and builds taxonomic lineages file (including 'representative' information)
  - builds database zipfiles (with abundance) by checking for signatures in `wort`
- `releases.smk`:
  - builds non-abundance zip, sbt, lca databases from the zipfiles

Notes: 
- For this release, I manually ran an extra `sig extract` step on the abundance zipfiles because of https://github.com/sourmash-bio/sourmash/issues/2617
e.g. - `sourmash sig extract gtdb-rs214-k21.abund.bak.zip -o gtdb-rs214-k21.abund.zip --picklist gtdb-rs214.manifest.csv:name:name --ksize 21`. I have not included that here because it required code in https://github.com/sourmash-bio/sourmash/pull/2602, and it will hopefully be solved by the next release.
- As mentioned in #1, non-abund zip building feels a bit redundant (as it doesn't save much space) and could potentially be eliminated in a future release.